### PR TITLE
[Feature] Add flag to keep input files after transcoding

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -49,7 +49,6 @@ enum Opt {
         /// Keep input files after transcoding
         #[structopt(short, long, name = "KEEP")]
         keep: bool,
-
     },
 
     #[structopt(external_subcommand)]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -46,6 +46,10 @@ enum Opt {
         /// %a with the song album.
         #[structopt(name = "PATTERN", default_value = "%F.%E")]
         output: String,
+        /// Keep input files after transcoding
+        #[structopt(short, long, name = "KEEP")]
+        keep: bool,
+
     },
 
     #[structopt(external_subcommand)]
@@ -55,7 +59,7 @@ enum Opt {
 fn main() {
     if let Err(e) = match Opt::from_args() {
         Opt::Play { file, volume } => play(file, volume),
-        Opt::Transcode { glob, output } => transcode::main(glob, output),
+        Opt::Transcode { glob, output, keep } => transcode::main(glob, output, keep),
         Opt::Interactive(queue) => interactive::main(queue),
     } {
         eprintln!("{:#}", e);

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -47,7 +47,7 @@ enum Opt {
         #[structopt(name = "PATTERN", default_value = "%F.%E")]
         output: String,
         /// Keep input files after transcoding
-        #[structopt(short, long, name = "KEEP")]
+        #[structopt(short, long)]
         keep: bool,
     },
 

--- a/cli/src/transcode.rs
+++ b/cli/src/transcode.rs
@@ -15,8 +15,10 @@ const WAV_MAGIC_NUMBER_OFFSET: usize = 8;
 
 pub fn main(glob: String, output: String, keep: bool) -> crate::Result {
     let files = glob::glob(&glob)?;
-    let results: Vec<anyhow::Result<(PathBuf, PathBuf)>> =
-        files.par_bridge().map(|r| transcode(r?, &output, keep)).collect();
+    let results: Vec<anyhow::Result<(PathBuf, PathBuf)>> = files
+        .par_bridge()
+        .map(|r| transcode(r?, &output, keep))
+        .collect();
     for r in results {
         match r {
             Ok((i, o)) => println!("`{}` -> `{}`", i.display(), o.display()),

--- a/cli/src/transcode.rs
+++ b/cli/src/transcode.rs
@@ -98,7 +98,7 @@ fn transcode(filename: PathBuf, output: &str, keep: bool) -> anyhow::Result<(Pat
         _ => lilac.write_file(&outfile)?,
     }
 
-    if keep == false {
+    if !keep {
         fs::remove_file(&filename)?;
     }
     Ok((filename, outfile))


### PR DESCRIPTION
By default will cleanup input files. This was picked over `--remove` due to how gzip and similar CLI tools handle by default.